### PR TITLE
Upgrade recursive-open-struct dependency

### DIFF
--- a/impact_radius_api.gemspec
+++ b/impact_radius_api.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "htmlentities", "~> 4.3", ">= 4.3.2"
   spec.add_dependency "httparty", "~> 0.13"
   spec.add_dependency "json", "~> 1.8", ">= 1.8.1"
-  spec.add_dependency "recursive-open-struct", "~> 0.5", ">= 0.5.0"
+  spec.add_dependency "recursive-open-struct", "~> 1.0", ">= 1.0.5"
 end


### PR DESCRIPTION
`recursive-open-struct` version 0.5.0 is 3 years old, so I upgraded it to the latest version.

The latest (1.0.5) has [breaking changes](https://github.com/aetherknight/recursive-open-struct/blob/master/CHANGELOG.md#100--2015-12-11) to the `#to_h` method, but this should not impact the `impact_radius_api` gem.